### PR TITLE
add animation back and overwrite games displays same frame

### DIFF
--- a/src/UI.cs
+++ b/src/UI.cs
@@ -56,7 +56,7 @@ public static class UI
     private static void OpenModSettingsMenu()
     {
         MenuState.I.mainPage.SetPageActive(false, false);
-        modMenuSP.SetPageActive(true, true);
+        modMenuSP.SetPageActive(false, true);
         MelonCoroutines.Start(WaitForPageOpen(PreparePage));
     }
 
@@ -258,9 +258,10 @@ public static class UI
 
     static IEnumerator WaitForPageOpen(Action callback)
     {
-        yield return new WaitForSeconds(0.1f);
-        callback.Invoke();
-        yield return null;
+		while (modMenuOM.transform.childCount < 5) {
+			yield return null;
+	    }
+	    callback.Invoke();
     }
 
     public static MinMaxStepDefault ParseMinMaxStep(string input)


### PR DESCRIPTION
this isnt ideal (not tested), dont have to accept this PR however i saw the potential for this to work and thought to note it somewhere

at a guess you had the animation disabled because games cycle, if you wait for the game to fill the display and then instantly overwrite it you can have the whole animation without the display popin and wont show anything visually weird and no need for timers

this SHOULD work as is but again not tested